### PR TITLE
nb_NO (Norwegian Bokmål) translation

### DIFF
--- a/assets/i18n/nb_NO.yaml
+++ b/assets/i18n/nb_NO.yaml
@@ -1,0 +1,289 @@
+global:
+  partido_title: Partido
+  locale: nb_NO
+  copied: Kopiert
+  close: Lukk
+  cancel: Avbryt
+  date_format: dd-MM-yyyy
+  date_format_short: dd-MM
+  currency_format: '###0,00'
+  part_format: '###0,###'
+home:
+  welcome:
+    title: Velkommen til Partido
+    subtitle: Velg et alternativ for å begynne
+    info: Opprett en ny gruppe og inviter venner til den for å dele utgifter.
+    info2: Eller ta del i en eksiterende gruppe hvis du fikk en kode fra en venn.
+    group_settings_tooltip: Gruppeinnstillinger
+    open_my_groups: Åpne mine grupper
+    create_new_group: Opprett en ny gruppe
+    join_existing_group: Ta del i en venns gruppe
+  balances:
+    title: Saldoer
+    need_more_users_info: Nyttig data vises her når minst én person tar del i gruppen din.
+  join_mode:
+    title_enabled: Deltagelsesmodus påslått
+    info: "Del følgende deltagelseskode med dine venner for å la dem ta del i gruppen."
+    security_notice: "Av sikkerhetshensyn kan du skru av grippedeltagelse når alle brukerne har tatt del i gruppen."
+    share:
+      text: >-
+        Last ned Partido-programmet fra Google Play-butikken
+        https://play.google.com/store/apps/details?id=net.fosforito.partido
+        og ta del i min gruppe med følgende kode ( mer info om hvordan
+        man tar del i en gruppe på https://partido.rocks/faq/#join-group):
+      subject: Ta del i min gruppe på Partido.
+    faq_link: "https://partido.rocks/faq-groups/"
+    faq_tooltip: Åpne O-S-S
+  group_refreshed_toast: Gruppe oppdatert
+  menu:
+    account: Min konto
+    about: Om Partido
+    feedback: Send tilbakemedling
+  about_dialog:
+    title: Om Partido
+    homepage: Hjemmeside
+    homepage_url: 'https://partido.rocks/'
+    imprint: Sammendrag
+    imprint_url: 'https://partido.rocks/imprint/'
+    privacy_policy: Personvernspraksis
+    privacy_policy_url: 'https://partido.rocks/privacy/'
+  groups_dialog:
+    title: Mine grupper
+    join_existing_button: Ta del i eksisterende
+    create_button: Opprett ny
+  join_group_dialog:
+    title: Ta del i gruppe
+    join_code: Deltagelseskode
+    join_code_empty_validation_error: Skriv inn koden du har mottatt
+    join_code_invalid_validation_error: Angi en gyldig kode
+    join_code_not_found_validation_error: Fant ikke koden, eller så er den avskrudd
+    group_already_joined_validation_error: Du er allerede i denne gruppen
+    button_join: Ta del
+  create_entry_tooltip: Opprett oppføring
+  groups_tooltip: Grupper
+  list_empty: Ingen oppføringer enda …
+entry_form:
+  toast_entry_created: Ny oppføring opprettet
+  toast_failed_to_save_entry: Kunne ikke opprette oppføringen
+  toast_entry_updated: Oppføring oppdatert
+  toast_failed_to_update_entry: Kunne ikke oppdatere oppføringen
+  toast_entry_deleted: Oppføring slettet
+  toast_failed_to_delete_entry: En feil inntraff under sletting av oppføringen
+  delete_entry_dialog:
+    title: Slett oppføring
+    question: Slett denne oppføringen?
+    answer_no: 'Nei, avbryt'
+    answer_yes: 'Ja, slett'
+  parts: Deler
+  paid: Betalt
+  create_entry_title: Opprett oppføring
+  edit_entry_title: Rediger oppføring
+  delete_entry_tooltip: Slett oppføring
+  description: Beskrivelse
+  description_empty_validation_error: 'Angi en beskrivelse'
+  description_too_long_validation_error: Maks. 255 tegn
+  amount: Beløp
+  amount_empty_validation_error: 'Skriv inn totalt beløp'
+  amount_not_positive_validation_error: 'Angi et tall høyere enn 0'
+  date: Dato
+  create_entry_button: Opprett oppføring
+  update_entry_button: Oppdater oppføring
+  amount_of_splits_sum_not_total_validation_error: "De betalte summene må beløpe seg til totalsummen for oppføringen"
+  details_title: "Detaljer"
+  category: "Kategori"
+  select_category_dialog:
+    title: "Velg kategori"
+  split_faq_tooltip: "Åpne delt O-S-S"
+  split_faq_link: "https://partido.rocks/faq-entry-management/"
+entry_details:
+  title: Detaljer
+  created_by: Opprettet av
+  splits: Oppdelinger
+  parts: 'Deler:'
+  paid: 'Betalt:'
+account:
+  details: Detaljer
+  title: Min konto
+  logout_tooltip: Logg ut
+  username: Brukernavn
+  username_empty_validation_error: 'Skriv inn et brukernavn'
+  username_too_long_validation_error: Maks. 50 tegn
+  email: E-post
+  email_already_in_use_validation_error: "E-postadressen er allerede registrert"
+  email_empty_validation_error: 'Skriv inn e-postadressen din'
+  email_invalid_validation_error: 'Skriv inn en gyldig e-postadresse'
+  email_too_long_validation_error: Maks. 50 tegn
+  password: Passord
+  current_password_input_required: 'Skriv inn ditt nåværende passord'
+  change_password:
+    title: Endre passord
+    description: La stå tomt hvis du ikke vil endre ditt nåværende passord.
+    new_password: Nytt passord (valgfritt)
+    new_password_too_long_validation_error: Maks. 100 tegn
+    new_password_too_short_validation_error: Min. 8 tegn
+    new_password_confirmation: Bekreftelse av nytt passord
+    new_password_confirmation_not_matching_validation_error: Passordene samsvarer ikke
+  save_button: Lagre endringer
+  logout_dialog:
+    title: Logg ut
+    question: Logg ut?
+    answer_no: 'Nei, avbryt'
+    answer_yes: 'Ja, logg ut'
+  toast_account_settings_saved: Innstillinger lagret
+  toast_error_updating_account: Kunne ikke oppdatere kontoen
+  toast_login_failed: Kunne ikke logge inn. Prøv igjen senere.
+  verification_required_dialog:
+    title: Bekreftelse kreves
+    info: Bekreft e-postadressen din ved å klikke på lenken du fikk per e-post. Det kan hende den har havnet i søppelposten.
+    ok: OK
+  delete: Slett konto
+  delete_dialog:
+    title: Slett konto
+    question: Slett kontoen? Din info vil bli slettet fra databasen vår.
+    verification_info: Skriv «SLETT» (uten sitattegn, med store bokstaver) for å bekrefte sletting.
+    verification_word: SLETT
+    verification_field_label: Bekreft sletting
+    answer_delete: Bekreft
+    field_empty_validation_error: Feltet kan ikke stå tomt
+    wrong_verification_word_validation_error: Skriv inn riktig ord for å bekrefte sletting av konto
+    groups_not_settled_up_validation_error: Gjør opp alle grupper du er i før du sletter kontoen din
+group_form:
+  toast_group_created: Ny gruppe opprettet
+  toast_group_creation_failed: Kunne ikke opprette gruppe
+  toast_group_settings_saved: Gruppeinnstillinger lagret
+  toast_group_settings_saving_failed: Kunne ikke lagre gruppeinnstillinger
+  create_group_title: Opprett gruppe
+  group_settings_title: Gruppeinnstillinger
+  group_name: Gruppenavn
+  group_name_empty_validation_error: 'Skriv inn et gruppenavn'
+  group_name_too_long_validation_error: Maks. 255 tegn
+  group_description: Beskrivelse (valgfritt)
+  group_description_too_long_validation_error: Maks. 255 tegn
+  currency: Valuta
+  currency_empty_validation_error: 'Angi en valuta'
+  currency_too_long_validation_error: Maks. 3 tegn
+  activate_join_mode: La andre brukere ta del i gruppen med en kode
+  create_group_button: Opprett gruppe
+  save_changes_button: Lagre endringer
+  join_mode: Deltagelsesmodus
+  details: Detaljer
+  actions:
+    checkout: Gjør opp
+    leave_group: Forlat gruppen
+    delete_group: Slett gruppen
+  checkout_dialog:
+    title: Gjør opp
+    question: Gjør opp gruppen nå og tøm oppføringslisten?
+    info: Alle gruppemedlemmer vil få beskjed om oppgjøret via e-post med en liste over anbefalinger om kompensasjonsbetaling.
+    answer_no: Nei, avbryt
+    answer_yes: Ja, gjør opp
+    checkout_failed: En feil inntraff. Prøv igjen senere.
+    checkout_precondition_failed: Alle saldoene er i null. Det er ingenting å gjøre opp nå.
+    loading: Loster inn …
+  leave_group_dialog:
+    title: Forlat gruppen
+    question: Forlat gruppen?
+    answer_no: Nei, avbryt
+    answer_yes: Ja, forlat
+    group_not_settled_up_error: Gjør opp gruppen først
+    unexpected_error: En uventet feil inntraff
+login:
+  toast_login_failed: Kunne ikke logge inn. Prøv igjen.
+  login_failed_too_many_attempts: "For mange mislykkede innloggingsforsøk. Prøv igjen om fem minutter."
+  login_failed_not_verified: "Kontoen er ikke bekreftet. Sjekk e-posten din."
+  login_title: Logg inn
+  email: Email Adresse
+  email_empty_validation_error: 'Skriv inn e-postadressen din'
+  password: Passord
+  password_empty_validation_error: 'Skriv inn passordet ditt'
+  remember: Husk meg
+  login_button: Logg inn
+  signup_button: Registrer deg
+  login_failed_unauthorized: "Kunne ikke logge inn. Sjekk at detaljene stemmer."
+  forgot_password_button: Glemt passordet?
+forgot_password:
+  toast_password_reset_request_failed: Noe gikk galt. Prøv igjen senere.
+  title: Tilbakestill passordet
+  submit_button: Tilbakestill passord
+  request_success:
+    title: Tilbakestilling av passord forespurt
+    login_button: Gå til innloggingen
+    success_notice: Du har bedt om å få passordet ditt tilbakestilt.
+    additional_info: Hvis angitt e-postadresse er registrert får du en e-post for å bekrefte at du eier kontoen. Husk å sjekke søppelposten hvis du ikke får e-posten innen fem minutter.
+    additional_info_2: After clicking on the verification link in the email, you'll get a new password.
+signup:
+  title: Registrering
+  username: Brukernavn
+  password_empty_validation_error: 'Skriv inn et passord'
+  password_too_long_validation_error: Maks. 100 tegn
+  password_too_short_validation_error: Min. 8 tegn
+  password_confirmation: Passordbekreftelse
+  password_confirmation_not_matching_validation_error: Passordene samsvarer ikke
+  accept_privacy_text_before_link: "Jeg har lest og samtykker til "
+  accept_privacy_text_after_link: " for Partido"
+  privacy_policy_link_text: "personvernspraksisen"
+  privacy_policy_link_url: 'https://partido.rocks/privacy/'
+  privacy_policy_not_accepted_error: Du kan kun bruke Partido hvis du samtykker til
+  success:
+    title: Bekreftelse av e-postadresse kreves
+    success_notice: Du er registrert!
+    additional_info: Før du kan begynne å bruke Partido må du bekrefte e-postadressen din ved å klikke på lenken du fikk i e-posten du fikk.
+    additional_info_2: Du bør få anmodning om bekreftelse per e-post i løpet av et par minutter. Sjekk søppelposten din hvis du ikke finner den.
+    login_button: Du kan nå logge inn.
+entry:
+  categories:
+    SUBSCRIPTIONS_DONATIONS: "Abonnementer og donasjoner"
+    BARS_RESTAURANTS: "Barer og restauranter"
+    EDUCATION: "Utdannelse"
+    FOOD_GROCERIES: "Mat og dagligvarer"
+    FAMILY_FRIENDS: "Familie og venner"
+    LEISURE_ENTERTAINMENT: "Nytelse og underholdning"
+    HEALTH_DRUGSTORES: "Helse og apotek"
+    HOUSEHOLD_UTILITIES: "Husholdningsartikler og utstyr"
+    MEDIA_ELECTRONICS: "Media og elektronikk"
+    TRAVEL_VACATION: "Reise og ferie"
+    SHOPPING: "Shopping"
+    MISCELLANEOUS: "Ymse"
+    TAXES_DUTIES: "Skatt og avgifter"
+    TRANSPORT_CAR: "Transport og bil"
+    UNCATEGORIZED: "Ikke kategorisert"
+    INSURANCE_FINANCE: "Forsikring og finans"
+date:
+  TODAY: I dag
+  YESTERDAY: I går
+  THIS_WEEK: Denne uken
+  THIS_MONTH: Denne måneden
+  MONTH_1: Januar
+  MONTH_2: Februar
+  MONTH_3: Mars
+  MONTH_4: April
+  MONTH_5: Mai
+  MONTH_6: Juni
+  MONTH_7: Juli
+  MONTH_8: August
+  MONTH_9: September
+  MONTH_10: Oktober
+  MONTH_11: November
+  MONTH_12: Desember
+checkout_result:
+  title: Gjør opp
+  subtitle: Gruppen er gjort opp
+  success_notice: Gruppen din har blitt gjort opp og oppføringslisten har blitt tømt.
+  additional_info: Alle gruppemedlemmer vil motta e-post med ytterligere info om oppgjør, inkludert en liste over anbefalinger om kompensasjonsbetaling.
+  compensation_payments:
+    title: Kompensasjonsbetaling
+charts:
+  weekly_expenses:
+    title: Ukentlige utgifter
+    tooltip: Totalt
+  monthly_expenses:
+    title: Månedlige utgifter
+    tooltip: Totalt
+  dashboard:
+    title: Utgifter
+    this_week: Denne uken
+    last_week: Siste uke
+    this_month: Denne måneden
+    last_month: Forrige måned
+  tips:
+    long_press_description: Lang-trykk på diagrammet for flere detaljer


### PR DESCRIPTION
@jenslw Would be great to have this on Weblate in some capacity.
That way it is easier to fix errors in translation.

activate_join_mode: → This is called a key when it should be code?
"All group members will be notified about the settle  up via email" → extra whitespace
"Account not verified. Please check your emails" → e-mail inbox?
Logout → Log out

And so on.